### PR TITLE
本番環境でログイン失敗していた

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.25'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -30,15 +30,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_LAMBDA_DEPLOY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Build Go application for Lambda
+      - name: Build and Zip Go application for Lambda
         working-directory: ./back
         run: |
-          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-
-      - name: Zip build artifact
-        working-directory: ./back
-        run: |
-          zip lambda-handler.zip bootstrap
+          make build-lambda
 
       - name: Update Lambda function code
         run: |

--- a/back/Makefile
+++ b/back/Makefile
@@ -1,3 +1,16 @@
 generate-go:
 	oapi-codegen -generate types -o internal/api/types.gen.go -package api openapi.yaml
 	oapi-codegen -generate chi-server -o internal/api/server.gen.go -package api openapi.yaml
+
+build-lambda:
+	# AWS Lambda向けのGoバイナリをビルドします。
+	# glibcのバージョン問題に対応するため、linux/amd64向けにクロスコンパイルし、静的リンクします。
+	# 出力ファイル名はAWS Lambdaの規約に従い 'bootstrap' とします。
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap -ldflags="-s -w" .
+	# 既存のzipファイルを削除し、クリーンな状態で再作成します。
+	rm -f lambda-handler.zip
+	# ビルドしたバイナリをzipファイルに圧縮します。
+	zip lambda-handler.zip bootstrap
+	# 一時的な 'bootstrap' ファイルを削除します。
+	rm bootstrap
+

--- a/confirmation.txt
+++ b/confirmation.txt
@@ -1,0 +1,8 @@
+はい、この変更内容をmainブランチにマージしてGitHub Actionsのワークフローが実行されれば、`/var/task/bootstrap: /lib64/libc.so.6: version GLIBC_2.34' not found (required by /var/task/bootstrap)`のエラーは解決されるはずです。
+
+変更点：
+1.  `back/Makefile`に、AWS Lambda向けにGoアプリケーションを静的にクロスコンパイルし、クリーンな`lambda-handler.zip`を作成する`build-lambda`ターゲットを追加しました。静的ビルドは通常、実行環境の`glibc`に依存しないため、バージョン不一致の問題を解消します。
+2.  `.github/workflows/deploy-lambda.yml`のビルドステップを、この新しい`make build-lambda`ターゲットを呼び出すように修正しました。これにより、AWS Lambdaデプロイメントが改善されたビルドプロセスを使用するようになります。
+3.  `go-version`を`1.21`から`1.25`に更新し、Goのバージョンの一貫性を確保しました。
+
+これらの変更により、Lambdaの実行環境と互換性のあるバイナリが生成され、デプロイされるため、問題が解決されると期待されます。


### PR DESCRIPTION
## 本番環境でログイン失敗していた原因
1. 今回のエラーは、Goアプリケーションがビルドされた環境のglibc（C標準ライブラリ）のバージョン（GLIBC_2.34）が、AWS Lambdaの実行環境で提供されているglibcのバージョンよりも新しいため、互換性がなく実行できないことが原因です。
2. 解決策として、`CGO_ENABLED=0`を設定し、Goアプリケーションを静的にリンクすることで、glibcへの依存をなくし、どのような環境でも実行できるようにしました。


## 修正内容
変更点：
   1. back/Makefileに、AWS
      Lambda向けにGoアプリケーションを静的にクロスコンパイルし、クリーンなlambda-handler.zipを作成するbuil
      d-lambdaターゲットを追加しました。静的ビルドは通常、実行環境のglibcに依存しないため、バージョン不一
      致の問題を解消します。
   4. .github/workflows/deploy-lambda.ymlのビルドステップを、この新しいmake
      build-lambdaターゲットを呼び出すように修正しました。これにより、AWS
      Lambdaデプロイメントが改善されたビルドプロセスを使用するようになります。
   5. go-versionを1.21から1.25に更新し、Goのバージョンの一貫性を確保しました。