### PR TITLE
LINEコールバック見直し

### DIFF
--- a/back/controller/line_auth_controller.go
+++ b/back/controller/line_auth_controller.go
@@ -58,6 +58,10 @@ func (ctrl *LineLoginControllerImpl) Login(c *gin.Context) {
 }
 
 // Callback はLINE認証後のコールバックを処理します。
+// 以前はLINEからの直接のリダイレクトを受け取っていましたが、
+// 今後はフロントエンドから認可コードとstateを受け取り、
+// トークン交換とCookie設定を行います。
+// 処理後、フロントエンドへのリダイレクトは行わず、成功ステータスをJSONで返します。
 func (ctrl *LineLoginControllerImpl) Callback(c *gin.Context) {
 	code := c.Query("code")
 	state := c.Query("state")
@@ -118,10 +122,6 @@ func (ctrl *LineLoginControllerImpl) Callback(c *gin.Context) {
 	http.SetCookie(c.Writer, tokenCookie)
 	http.SetCookie(c.Writer, loggedInCookie)
 
-	// フロントエンドのログイン成功時のリダイレクトURL
-	redirectURL := fmt.Sprintf("%s/budget", os.Getenv("FE_URL")) // FE_URLはフロントエンドのドメイン
-	if os.Getenv("FE_URL") == "" {
-		redirectURL = "http://localhost:3000/budget" // ローカル開発用フォールバック
-	}
-	c.Redirect(http.StatusTemporaryRedirect, redirectURL)
+	// フロントエンドは別途リダイレクトを行うため、ここでは成功を返すのみ
+	c.JSON(http.StatusOK, gin.H{"message": "LINEログインに成功しました"})
 }

--- a/back/openapi.yaml
+++ b/back/openapi.yaml
@@ -66,8 +66,16 @@ paths:
           required: true
           description: State parameter for CSRF protection
       responses:
-        '302':
-          description: Redirect to frontend application after successful login
+        '200':
+          description: LINE login successful. Sets JWT cookie.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "LINEログインに成功しました"
         '400':
           description: Invalid code or state
         '401':

--- a/front/src/app/api/lineAuthCallback.ts
+++ b/front/src/app/api/lineAuthCallback.ts
@@ -1,0 +1,30 @@
+// front/src/app/api/lineAuthCallback.ts
+
+type LineAuthCallbackResponse = {
+  message: string;
+};
+
+type LineAuthCallbackError = {
+  error: string;
+};
+
+export async function lineAuthCallback(
+  code: string,
+  state: string,
+): Promise<LineAuthCallbackResponse> {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/line/callback?code=${code}&state=${state}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: 'include',
+    },
+  );
+
+  if (!response.ok) {
+    const errorData: LineAuthCallbackError = await response.json();
+    throw new Error(errorData.error || "LINEログインに失敗しました。");
+  }
+
+  return response.json();
+}

--- a/front/src/types/api.ts
+++ b/front/src/types/api.ts
@@ -138,12 +138,17 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description Redirect to frontend application after successful login */
-                302: {
+                /** @description LINE login successful. Sets JWT cookie. */
+                200: {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            /** @example LINEログインに成功しました */
+                            message?: string;
+                        };
+                    };
                 };
                 /** @description Invalid code or state */
                 400: {
@@ -439,7 +444,7 @@ export interface components {
         UserResponse: {
             id: number;
             /** Format: email */
-            email: string;
+            email?: string | null;
             name: string;
             image?: string;
             admin: boolean;


### PR DESCRIPTION
目的と修正内容の解説


  LINEログインにおける「SPでLINEログインを実行するとメアド、パスワード入力を毎回求められる」という問題と、
  それに付随するCookie保持の問題を解決するため、以下の目的と修正を行いました。

  今回の目的:


   1. LINEログイン体験の改善:
      ユーザーがLINEログイン時に毎回メールアドレスやパスワードの入力を求められることなく、スムーズにログイ
      ンできるようにする。特にSP（スマートフォン）環境でのUniversal Linkによる自動ログインを機能させる。
   2. Cookieの適切な保持:
      バックエンドで発行された認証Cookieがフロントエンドに正しく送信・保持され、その後のAPIリクエストで利
      用できるようにする。
   3. API仕様と連携の明確化:
      バックエンドのAPI定義を現在の動作に合わせ、フロントエンドのAPI呼び出しを整理する。

  行った修正と解説:

  1. バックエンド（Go言語）の修正


   * `back/usecase/line_login_usecase.go` の変更
       * 修正内容: GetLineAuthURL 関数から、LINE認可URL生成時のパラメータoauth2.SetAuthURLParam("prompt",
         "consent")とoauth2.SetAuthURLParam("bot_prompt", "aggressive")を削除しました。
       * 解説:
         prompt=consentがある場合、LINEはユーザーが既にアプリを認証していても毎回同意画面を表示します。こ
         れにより、不要なメール/パスワードの入力が頻繁に発生していました。このパラメータを削除することで、
         ユーザーが一度同意していれば、LINEセッションが有効な限り同意画面がスキップされ、スムーズなログイ
         ンが可能になりました。bot_prompt=aggressiveは友達追加のプロンプトで、これもユーザー体験を損ねる可
         能性があったため削除しました。


   * `back/controller/line_auth_controller.go` の変更
       * 修正内容: Callback
         関数の動作を変更しました。以前はLINE認証後、バックエンドからフロントエンドへの直接リダイレクトを
         行っていましたが、これを削除しました。代わりに、認証処理（コード交換、JWT生成、認証Cookie設定）を
         完了した後、200 OK ステータスとJSONメッセージ（{"message":
         "LINEログインに成功しました"}）を返すように変更しました。また、Cookie設定のロジックは維持し、Secu
         re、SameSite、Domain属性の扱いについて、開発環境と本番環境での適切な動作を考慮しました。
       * 解説:
         LINEログインの「正しい折衷解」として、LINEからのリダイレクトは一度フロントエンドに受け渡され、フ
         ロントエンドがそのコードと状態を使ってバックエンドにAPIコールを行う形式が推奨されます。この変更に
         より、バックエンドはAPIエンドポイントとして機能し、認証完了をJSONでフロントエンドに通知するように
         なりました。


   * `back/openapi.yaml` の変更
       * 修正内容: /api/v1/auth/line/callback
         エンドポイントのOpenAPI定義において、レスポンスコードを302（リダイレクト）から200（成功）に変更し
         、返されるJSONスキーマを記述しました。
       * 解説:
         バックエンドのCallback関数の動作変更に合わせて、APIの定義も最新の状態に保ちました。これにより、AP
         Iの利用者が正確なレスポンス形式を把握できるようになります。

  2. フロントエンド（Next.js / TypeScript）の修正（提供、ユーザー側で実装）


   * `front/src/app/api/lineAuthCallback.ts` の新規作成
       * 修正内容:
         バックエンドの/api/v1/auth/line/callbackエンドポイントを呼び出すための専用のユーティリティ関数lin
         eAuthCallbackを作成しました。この関数内で、process.env.NEXT_PUBLIC_API_URLを使用してバックエンド
         の絶対URLを構築し、credentials: 'include'オプションをfetchリクエストに追加しました。
       * 解説:
         API呼び出しロジックを独立させることで、コードの再利用性と保守性を高めました。process.env.NEXT_PUB
         LIC_API_URLを使うことで、開発環境と本番環境でバックエンドのURLを自動的に切り替えることができます
         。また、credentials:
         'include'は、フロントエンド（異なるオリジン）からバックエンドへのAPIリクエスト時に、バックエンド
         によって設定されたCookieをブラウザが自動的に送信するようにするために不可欠です。これがCookie保持
         の鍵となりました。


   * `front/src/app/auth/callback/page.tsx` の修正
       * 修正内容:
         このコンポーネントは、LINEからのリダイレクト（フロントエンドURL）で呼び出され、URLクエリパラメー
         タからcodeとstateを抽出します。抽出した情報を使って、新しく作成したlineAuthCallback関数を呼び出し
         、認証処理を実行します。成功時にはrouter.push('/budget')で/budgetページへ遷移し、エラー発生時には
         エラーメッセージを表示します。また、自身のローディングUIは削除し、Next.jsのloading.tsxにローディ
         ング表示を委ねるように変更しました。
       * 解説:
         LINEがフロントエンドURLにリダイレクトする際の受け口となり、実際の認証処理をバックエンドAPIに依頼
         し、完了後に適切なページへユーザーを誘導する役割を担います。credentials:
         'include'が機能することで、バックエンドが設定した認証Cookieをフロントエンドが受け継ぎ、ログイン状
         態を維持できるようになりました。


   * `front/src/app/api/fetchBudgetList.ts` の修正
       * 修正内容: cookies()関数の呼び出しをawait
         cookies()に変更し、cookieStore.toString()を使わずにcookieStore.entries()を使ってCookieヘッダー文
         字列を手動で構築するようにしました。また、このAPI呼び出しにもcredentials:
         'include'オプションを追加しました。
       * 解説: Next.jsのServer
         Componentでcookies()を利用する際の動的APIに関するエラーを解決しました。これにより、Server
         ComponentからバックエンドAPIを呼び出す際に認証Cookieが正しく付与されるようになりました。credentia
         ls: 'include'は、lineAuthCallbackと同様にCookie保持のために重要です。

  3. 環境設定（ユーザーによる対応）

   * LINE Developers ConsoleのCallback URL: フロントエンドのCallback URL（例:
     http://localhost:3000/auth/callback や https://budget-mambo.work/auth/callback）を追加登録。
   * バックエンドの`LINE_REDIRECT_URI`環境変数: フロントエンドのCallback URLに設定。
   * フロントエンドの`NEXT_PUBLIC_API_URL`環境変数: バックエンドAPIのURL（例: http://localhost:8080 や
     https://api.budget-mambo.work）に設定。