### PR TITLE
emailで登録したユーザーとLINEログインを紐づける

### DIFF
--- a/back/controller/line_auth_controller.go
+++ b/back/controller/line_auth_controller.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yanatoritakuma/budget/back/internal/api"
 	"github.com/yanatoritakuma/budget/back/model"
 	"github.com/yanatoritakuma/budget/back/usecase"
 )
@@ -15,6 +16,8 @@ import (
 type LineLoginController interface {
 	Login(c *gin.Context)
 	Callback(c *gin.Context)
+	LinkAccount(c *gin.Context)
+	CreateAccount(c *gin.Context)
 }
 
 // LineLoginControllerImpl はLineLoginControllerの実装です。
@@ -58,10 +61,6 @@ func (ctrl *LineLoginControllerImpl) Login(c *gin.Context) {
 }
 
 // Callback はLINE認証後のコールバックを処理します。
-// 以前はLINEからの直接のリダイレクトを受け取っていましたが、
-// 今後はフロントエンドから認可コードとstateを受け取り、
-// トークン交換とCookie設定を行います。
-// 処理後、フロントエンドへのリダイレクトは行わず、成功ステータスをJSONで返します。
 func (ctrl *LineLoginControllerImpl) Callback(c *gin.Context) {
 	code := c.Query("code")
 	state := c.Query("state")
@@ -71,32 +70,160 @@ func (ctrl *LineLoginControllerImpl) Callback(c *gin.Context) {
 		return
 	}
 
-	// stateの検証（セッションIDとして state を使用）
+	// stateの検証
 	sessionID := fmt.Sprintf("line-login-%s", state)
 	if !ctrl.tokenStore.ValidateToken(sessionID, state) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid state"})
 		return
 	}
-	ctrl.tokenStore.DeleteToken(sessionID) // stateは一度使用したら削除
+	ctrl.tokenStore.DeleteToken(sessionID)
 
-	// LINEログインの処理を行い、JWTを取得
-	jwtToken, err := ctrl.lineLoginUsecase.LineLoginCallback(c.Request.Context(), code, state)
+	// LINEログインの処理
+	token, claims, err := ctrl.lineLoginUsecase.LineLoginCallback(c.Request.Context(), code, state)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("LINE login failed: %v", err)})
 		return
 	}
 
-	// Cookie domain を安全に設定（ホスト名のみ）
 	domain := os.Getenv("API_DOMAIN")
-	isSecure := os.Getenv("GO_ENV") != "dev" // 本番環境では secure=true
+	isSecure := os.Getenv("GO_ENV") != "dev"
 
-	// http.Cookie構造体を作成
+	// ユーザーが存在する場合（ログイン成功）
+	if token != "" {
+		tokenCookie := &http.Cookie{
+			Name:     "token",
+			Value:    token,
+			MaxAge:   60 * 60 * 12, // 12時間
+			Path:     "/",
+			Domain:   domain,
+			Secure:   isSecure,
+			HttpOnly: true,
+			SameSite: http.SameSiteNoneMode,
+		}
+		loggedInCookie := &http.Cookie{
+			Name:     "logged_in",
+			Value:    "true",
+			MaxAge:   60 * 60 * 12, // 12時間
+			Path:     "/",
+			Domain:   domain,
+			Secure:   isSecure,
+			HttpOnly: false,
+			SameSite: http.SameSiteNoneMode,
+		}
+
+		if !isSecure {
+			tokenCookie.SameSite = http.SameSiteLaxMode
+			loggedInCookie.SameSite = http.SameSiteLaxMode
+		}
+
+		http.SetCookie(c.Writer, tokenCookie)
+		http.SetCookie(c.Writer, loggedInCookie)
+		c.JSON(http.StatusOK, gin.H{"status": "logged_in", "message": "LINEログインに成功しました"})
+		return
+	}
+
+	// ユーザーが存在しない場合（未登録）
+	if claims != nil {
+		// プレ認証トークンの生成
+		preAuthToken, err := ctrl.lineLoginUsecase.GeneratePreAuthToken(claims.Subject, claims.Name, claims.Picture)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate pre-auth token"})
+			return
+		}
+
+		preAuthCookie := &http.Cookie{
+			Name:     "line_pre_auth",
+			Value:    preAuthToken,
+			MaxAge:   60 * 30, // 30分
+			Path:     "/",
+			Domain:   domain,
+			Secure:   isSecure,
+			HttpOnly: true,
+			SameSite: http.SameSiteNoneMode,
+		}
+		if !isSecure {
+			preAuthCookie.SameSite = http.SameSiteLaxMode
+		}
+		http.SetCookie(c.Writer, preAuthCookie)
+
+		c.JSON(http.StatusOK, gin.H{
+			"status":       "unregistered",
+			"line_name":    claims.Name,
+			"line_picture": claims.Picture,
+		})
+		return
+	}
+
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "Unexpected login state"})
+}
+
+// LinkAccount は既存アカウントとLINEアカウントを紐付けます。
+func (ctrl *LineLoginControllerImpl) LinkAccount(c *gin.Context) {
+	preAuthToken, err := c.Cookie("line_pre_auth")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No pending LINE login found"})
+		return
+	}
+
+	var req api.LinkAccountRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		return
+	}
+
+	token, err := ctrl.lineLoginUsecase.LinkLineAccount(c.Request.Context(), preAuthToken, string(req.Email), req.Password)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 成功時のCookie設定
+	ctrl.setLoginCookies(c, token)
+	c.JSON(http.StatusOK, gin.H{"message": "Account linked successfully"})
+}
+
+// CreateAccount はLINEアカウントから新規ユーザーを作成します。
+func (ctrl *LineLoginControllerImpl) CreateAccount(c *gin.Context) {
+	preAuthToken, err := c.Cookie("line_pre_auth")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No pending LINE login found"})
+		return
+	}
+
+	token, err := ctrl.lineLoginUsecase.CreateUserFromLine(c.Request.Context(), preAuthToken)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// 成功時のCookie設定
+	ctrl.setLoginCookies(c, token)
+	c.JSON(http.StatusCreated, gin.H{"message": "Account created successfully"})
+}
+
+// setLoginCookies はログイン成功時の共通Cookie設定を行います。
+func (ctrl *LineLoginControllerImpl) setLoginCookies(c *gin.Context, token string) {
+	domain := os.Getenv("API_DOMAIN")
+	isSecure := os.Getenv("GO_ENV") != "dev"
+
+	// Pre-Auth Cookieの削除
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     "line_pre_auth",
+		Value:    "",
+		MaxAge:   -1,
+		Path:     "/",
+		Domain:   domain,
+		Secure:   isSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteNoneMode,
+	})
+
 	tokenCookie := &http.Cookie{
 		Name:     "token",
-		Value:    jwtToken,
-		MaxAge:   60 * 60 * 12, // 12時間
+		Value:    token,
+		MaxAge:   60 * 60 * 12,
 		Path:     "/",
-		Domain:   os.Getenv("API_DOMAIN"),
+		Domain:   domain,
 		Secure:   isSecure,
 		HttpOnly: true,
 		SameSite: http.SameSiteNoneMode,
@@ -104,7 +231,7 @@ func (ctrl *LineLoginControllerImpl) Callback(c *gin.Context) {
 	loggedInCookie := &http.Cookie{
 		Name:     "logged_in",
 		Value:    "true",
-		MaxAge:   60 * 60 * 12, // 12時間
+		MaxAge:   60 * 60 * 12,
 		Path:     "/",
 		Domain:   domain,
 		Secure:   isSecure,
@@ -112,16 +239,11 @@ func (ctrl *LineLoginControllerImpl) Callback(c *gin.Context) {
 		SameSite: http.SameSiteNoneMode,
 	}
 
-	// 開発環境など非セキュアな場合はSameSiteをLaxに設定
 	if !isSecure {
 		tokenCookie.SameSite = http.SameSiteLaxMode
 		loggedInCookie.SameSite = http.SameSiteLaxMode
 	}
 
-	// レスポンスヘッダーに直接Cookieを設定
 	http.SetCookie(c.Writer, tokenCookie)
 	http.SetCookie(c.Writer, loggedInCookie)
-
-	// フロントエンドは別途リダイレクトを行うため、ここでは成功を返すのみ
-	c.JSON(http.StatusOK, gin.H{"message": "LINEログインに成功しました"})
 }

--- a/back/internal/api/server.gen.go
+++ b/back/internal/api/server.gen.go
@@ -16,6 +16,12 @@ type ServerInterface interface {
 	// LINE login callback
 	// (GET /api/v1/auth/line/callback)
 	GetApiV1AuthLineCallback(w http.ResponseWriter, r *http.Request, params GetApiV1AuthLineCallbackParams)
+	// Create new user from LINE account
+	// (POST /api/v1/auth/line/create)
+	PostApiV1AuthLineCreate(w http.ResponseWriter, r *http.Request)
+	// Link LINE account to existing user
+	// (POST /api/v1/auth/line/link)
+	PostApiV1AuthLineLink(w http.ResponseWriter, r *http.Request)
 	// Initiate LINE login flow
 	// (GET /api/v1/auth/line/login)
 	GetApiV1AuthLineLogin(w http.ResponseWriter, r *http.Request)
@@ -46,6 +52,18 @@ type Unimplemented struct{}
 // LINE login callback
 // (GET /api/v1/auth/line/callback)
 func (_ Unimplemented) GetApiV1AuthLineCallback(w http.ResponseWriter, r *http.Request, params GetApiV1AuthLineCallbackParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create new user from LINE account
+// (POST /api/v1/auth/line/create)
+func (_ Unimplemented) PostApiV1AuthLineCreate(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Link LINE account to existing user
+// (POST /api/v1/auth/line/link)
+func (_ Unimplemented) PostApiV1AuthLineLink(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -140,6 +158,34 @@ func (siw *ServerInterfaceWrapper) GetApiV1AuthLineCallback(w http.ResponseWrite
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetApiV1AuthLineCallback(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostApiV1AuthLineCreate operation middleware
+func (siw *ServerInterfaceWrapper) PostApiV1AuthLineCreate(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostApiV1AuthLineCreate(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostApiV1AuthLineLink operation middleware
+func (siw *ServerInterfaceWrapper) PostApiV1AuthLineLink(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostApiV1AuthLineLink(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -427,6 +473,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/auth/line/callback", wrapper.GetApiV1AuthLineCallback)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/auth/line/create", wrapper.PostApiV1AuthLineCreate)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/auth/line/link", wrapper.PostApiV1AuthLineLink)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/auth/line/login", wrapper.GetApiV1AuthLineLogin)

--- a/back/internal/api/types.gen.go
+++ b/back/internal/api/types.gen.go
@@ -32,6 +32,12 @@ type ExpenseResponse struct {
 	UserId    int       `json:"user_id"`
 }
 
+// LinkAccountRequest defines model for LinkAccountRequest.
+type LinkAccountRequest struct {
+	Email    openapi_types.Email `json:"email"`
+	Password string              `json:"password"`
+}
+
 // SignUpRequest defines model for SignUpRequest.
 type SignUpRequest struct {
 	Email    openapi_types.Email `json:"email"`
@@ -76,6 +82,9 @@ type GetExpensesParams struct {
 	// Category Category to filter expenses
 	Category *string `form:"category,omitempty" json:"category,omitempty"`
 }
+
+// PostApiV1AuthLineLinkJSONRequestBody defines body for PostApiV1AuthLineLink for application/json ContentType.
+type PostApiV1AuthLineLinkJSONRequestBody = LinkAccountRequest
 
 // PostExpensesJSONRequestBody defines body for PostExpenses for application/json ContentType.
 type PostExpensesJSONRequestBody = ExpenseRequest

--- a/back/openapi.yaml
+++ b/back/openapi.yaml
@@ -51,7 +51,7 @@ paths:
       tags:
         - auth
       summary: LINE login callback
-      description: Handles the callback from LINE after user authentication. Sets JWT cookie and redirects.
+      description: Handles the callback from LINE. If user exists, logs in. If not, returns unregistered status.
       parameters:
         - in: query
           name: code
@@ -75,11 +75,61 @@ paths:
                 properties:
                   message:
                     type: string
-                    example: "LINEログインに成功しました"
+                  status:
+                    type: string
+                    enum: ["logged_in", "unregistered"]
+                  line_name:
+                    type: string
+                    description: Returned only if status is unregistered
+                  line_picture:
+                    type: string
+                    description: Returned only if status is unregistered
         '400':
           description: Invalid code or state
         '401':
           description: Invalid CSRF state
+        '500':
+          description: Internal server error
+  /api/v1/auth/line/link:
+    post:
+      tags:
+        - auth
+      summary: Link LINE account to existing user
+      description: Links a pending LINE account (from pre-auth cookie) to an existing email/password account.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LinkAccountRequest'
+      responses:
+        '200':
+          description: Account linked and logged in successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '400':
+          description: Invalid input or missing pre-auth cookie
+        '401':
+          description: Invalid credentials
+        '500':
+          description: Internal server error
+  /api/v1/auth/line/create:
+    post:
+      tags:
+        - auth
+      summary: Create new user from LINE account
+      description: Creates a new user using the pending LINE account information (from pre-auth cookie).
+      responses:
+        '201':
+          description: User created and logged in successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '400':
+          description: Missing pre-auth cookie
         '500':
           description: Internal server error
   /user:
@@ -230,6 +280,18 @@ components:
           type: string
         image:
           type: string
+    LinkAccountRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
     UserResponse:
       type: object
       required:

--- a/back/router/router.go
+++ b/back/router/router.go
@@ -92,6 +92,8 @@ func NewRouter(
 	// LINE Login routes
 	r.GET("/api/v1/auth/line/login", gin.HandlerFunc(lineLoginController.Login))
 	r.GET("/api/v1/auth/line/callback", gin.HandlerFunc(lineLoginController.Callback))
+	r.POST("/api/v1/auth/line/link", gin.HandlerFunc(lineLoginController.LinkAccount))
+	r.POST("/api/v1/auth/line/create", gin.HandlerFunc(lineLoginController.CreateAccount))
 
 	// -------------------------
 	// 認証必須ルート

--- a/front/src/app/api/lineAuthCallback.ts
+++ b/front/src/app/api/lineAuthCallback.ts
@@ -1,7 +1,10 @@
 // front/src/app/api/lineAuthCallback.ts
 
-type LineAuthCallbackResponse = {
-  message: string;
+export type LineAuthCallbackResponse = {
+  message?: string;
+  status: "logged_in" | "unregistered";
+  line_name?: string;
+  line_picture?: string;
 };
 
 type LineAuthCallbackError = {

--- a/front/src/app/api/lineAuthCallback.ts
+++ b/front/src/app/api/lineAuthCallback.ts
@@ -1,11 +1,7 @@
 // front/src/app/api/lineAuthCallback.ts
+import { paths } from "@/types/api";
 
-export type LineAuthCallbackResponse = {
-  message?: string;
-  status: "logged_in" | "unregistered";
-  line_name?: string;
-  line_picture?: string;
-};
+export type LineAuthCallbackResponse = paths["/api/v1/auth/line/callback"]["get"]["responses"]["200"]["content"]["application/json"];
 
 type LineAuthCallbackError = {
   error: string;

--- a/front/src/app/api/lineCreateAccount.ts
+++ b/front/src/app/api/lineCreateAccount.ts
@@ -1,0 +1,21 @@
+import { createHeaders } from "@/utils/getCsrf";
+
+type CreateAccountResponse = {
+  message: string;
+};
+
+export async function lineCreateAccount(): Promise<CreateAccountResponse> {
+  const headers = await createHeaders();
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/line/create`, {
+    method: 'POST',
+    headers: headers,
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || 'Failed to create account');
+  }
+
+  return response.json();
+}

--- a/front/src/app/api/lineLinkAccount.ts
+++ b/front/src/app/api/lineLinkAccount.ts
@@ -1,0 +1,22 @@
+import { createHeaders } from "@/utils/getCsrf";
+
+type LinkAccountResponse = {
+  message: string;
+};
+
+export async function lineLinkAccount(email: string, password: string): Promise<LinkAccountResponse> {
+  const headers = await createHeaders();
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/line/link`, {
+    method: 'POST',
+    headers: headers,
+    body: JSON.stringify({ email, password }),
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || 'Failed to link account');
+  }
+
+  return response.json();
+}

--- a/front/src/app/auth/callback/page.tsx
+++ b/front/src/app/auth/callback/page.tsx
@@ -20,9 +20,16 @@ export default function LineAuthCallbackPage() {
 
     const handleLineCallback = async () => {
       try {
-        await lineAuthCallback(code, state);
+        const data = await lineAuthCallback(code, state);
 
-        router.push("/budget");
+        if (data.status === "unregistered") {
+          const params = new URLSearchParams();
+          if (data.line_name) params.set("name", data.line_name);
+          if (data.line_picture) params.set("picture", data.line_picture);
+          router.push(`/auth/line-link?${params.toString()}`);
+        } else {
+          router.push("/budget");
+        }
       } catch (err) {
         setError("LINEログイン中にエラーが発生しました。");
         console.error("LINE Login Callback Error:", err);

--- a/front/src/app/auth/line-link/lineLink.module.scss
+++ b/front/src/app/auth/line-link/lineLink.module.scss
@@ -1,0 +1,107 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 20px;
+  background-color: #f5f5f5;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+}
+
+.profile {
+  margin-bottom: 20px;
+  
+  img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    margin-bottom: 10px;
+  }
+  
+  h2 {
+    font-size: 1.2rem;
+    color: #333;
+  }
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.divider {
+  border-top: 1px solid #eee;
+  margin: 10px 0;
+  position: relative;
+  
+  span {
+    position: absolute;
+    top: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: white;
+    padding: 0 10px;
+    color: #888;
+    font-size: 0.8rem;
+  }
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  
+  input {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 1rem;
+  }
+}
+
+.button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  
+  &.primary {
+    background-color: #007bff;
+    color: white;
+    &:hover {
+      background-color: #0056b3;
+    }
+  }
+  
+  &.secondary {
+    background-color: #28a745;
+    color: white;
+    &:hover {
+      background-color: #218838;
+    }
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+}
+
+.error {
+  color: #dc3545;
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+}

--- a/front/src/app/auth/line-link/page.tsx
+++ b/front/src/app/auth/line-link/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { lineLinkAccount } from "../../api/lineLinkAccount";
+import { lineCreateAccount } from "../../api/lineCreateAccount";
+import styles from "./lineLink.module.scss";
+
+export default function LineLinkPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const name = searchParams.get("name");
+  const picture = searchParams.get("picture");
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      await lineLinkAccount(email, password);
+      router.push("/budget");
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("アカウント連携に失敗しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    setError(null);
+    setLoading(true);
+
+    try {
+      await lineCreateAccount();
+      router.push("/budget");
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("アカウント作成に失敗しました。");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.card}>
+        <div className={styles.profile}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          {picture && <img src={picture} alt="LINE Profile" />}
+          <h2>{name ? `${name}さんとして認証中` : "LINE認証済み"}</h2>
+          <p>アカウントを連携するか、新規登録してください。</p>
+        </div>
+
+        {error && <p className={styles.error}>{error}</p>}
+
+        <div className={styles.options}>
+          <form className={styles.form} onSubmit={handleLink}>
+            <h3>既存のアカウントと連携</h3>
+            <input
+              type="email"
+              placeholder="メールアドレス"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <input
+              type="password"
+              placeholder="パスワード"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            <button type="submit" className={`${styles.button} ${styles.primary}`} disabled={loading}>
+              {loading ? "処理中..." : "連携してログイン"}
+            </button>
+          </form>
+
+          <div className={styles.divider}>
+            <span>または</span>
+          </div>
+
+          <div className={styles.form}>
+            <h3>新規アカウント作成</h3>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.secondary}`}
+              onClick={handleCreate}
+              disabled={loading}
+            >
+              {loading ? "処理中..." : "新規登録してログイン"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/app/auth/line-link/page.tsx
+++ b/front/src/app/auth/line-link/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { lineLinkAccount } from "../../api/lineLinkAccount";
 import { lineCreateAccount } from "../../api/lineCreateAccount";
 import styles from "./lineLink.module.scss";
 
-export default function LineLinkPage() {
+function LineLinkContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const name = searchParams.get("name");
@@ -83,7 +83,11 @@ export default function LineLinkPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
             />
-            <button type="submit" className={`${styles.button} ${styles.primary}`} disabled={loading}>
+            <button
+              type="submit"
+              className={`${styles.button} ${styles.primary}`}
+              disabled={loading}
+            >
               {loading ? "処理中..." : "連携してログイン"}
             </button>
           </form>
@@ -106,5 +110,13 @@ export default function LineLinkPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LineLinkPage() {
+  return (
+    <Suspense fallback={<div className={styles.container}>読み込み中...</div>}>
+      <LineLinkContent />
+    </Suspense>
   );
 }

--- a/front/src/types/api.ts
+++ b/front/src/types/api.ts
@@ -122,7 +122,7 @@ export interface paths {
         };
         /**
          * LINE login callback
-         * @description Handles the callback from LINE after user authentication. Sets JWT cookie and redirects.
+         * @description Handles the callback from LINE. If user exists, logs in. If not, returns unregistered status.
          */
         get: {
             parameters: {
@@ -145,8 +145,13 @@ export interface paths {
                     };
                     content: {
                         "application/json": {
-                            /** @example LINEログインに成功しました */
                             message?: string;
+                            /** @enum {string} */
+                            status?: "logged_in" | "unregistered";
+                            /** @description Returned only if status is unregistered */
+                            line_name?: string;
+                            /** @description Returned only if status is unregistered */
+                            line_picture?: string;
                         };
                     };
                 };
@@ -175,6 +180,123 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/line/link": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Link LINE account to existing user
+         * @description Links a pending LINE account (from pre-auth cookie) to an existing email/password account.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["LinkAccountRequest"];
+                };
+            };
+            responses: {
+                /** @description Account linked and logged in successfully */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserResponse"];
+                    };
+                };
+                /** @description Invalid input or missing pre-auth cookie */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Invalid credentials */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/line/create": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create new user from LINE account
+         * @description Creates a new user using the pending LINE account information (from pre-auth cookie).
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description User created and logged in successfully */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserResponse"];
+                    };
+                };
+                /** @description Missing pre-auth cookie */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Internal server error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -440,6 +562,12 @@ export interface components {
             password: string;
             name: string;
             image?: string;
+        };
+        LinkAccountRequest: {
+            /** Format: email */
+            email: string;
+            /** Format: password */
+            password: string;
         };
         UserResponse: {
             id: number;


### PR DESCRIPTION
1. LINEログインボタン押下
    - ユーザーがLINE認証を行う。
2. バックエンド判定
    - line_user_id が既にDBにある → ログイン成功
    - line_user_id がDBにない → 未登録状態として扱う（即座に新規作成しない）。
3. フロントエンド分岐（未登録の場合）
    - 画面に「アカウントの連携、または新規作成」を表示。
    - 選択A（既存アカウントと連携）:
        - 「メールアドレス」と「パスワード」を入力させる。
        - バックエンドで検証し、合致すれば既存ユーザーの line_user_id を更新して紐付ける。
    - 選択B（新規作成）:
        - そのまま新規ユーザーとして作成する。